### PR TITLE
Fix Patient ID bug and change build environment

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,2 +1,3 @@
+^codecov\.yml$
 ^.*\.Rproj$
 ^\.Rproj\.user$

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-langauge: generic
+langauge: r
 cache: packages
 sudo: required
 
@@ -6,9 +6,6 @@ addons:
   apt:
     packages:
       - r-base-dev
-
-script:
-  - R CMD build .
 
 r_packages:
   - devtools
@@ -25,3 +22,20 @@ r_packages:
 r_github_packages:
   - OHDSI/DatabaseConnector
   - OHDSI/SqlRender
+
+notifications:
+  email:
+    on_success: change
+    on_failure: change
+
+before_script:
+  - wget -P ~ $CT_SAMPLE
+  - mkdir ~/signedrangeimages
+  - tar -xvf ~/signedrangeimages.tar.bz2 -C ~/signedrangeimages
+
+script:
+  - R CMD build .
+  - R CMD INSTALL *.tar.gz --library=$R_LIB_PATH
+
+after_success:
+  - Rscript tests/testRadETL.R

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
-langauge: r
+language: r
 cache: packages
-sudo: required
+sudo: false
 
-addons:
-  apt:
-    packages:
-      - r-base-dev
+r:
+  - 3.4.4
+  - release
 
 r_packages:
   - devtools
@@ -18,6 +17,7 @@ r_packages:
   - R6
   - parallel
   - stringr
+  - covr
 
 r_github_packages:
   - OHDSI/DatabaseConnector
@@ -35,7 +35,8 @@ before_script:
 
 script:
   - R CMD build .
-  - R CMD INSTALL *.tar.gz --library=$R_LIB_PATH
+  - Rscript -e "devtools::install_git('.')"
 
 after_success:
   - Rscript tests/testRadETL.R
+  - Rscript -e 'library(covr); codecov()'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: RadETL
 Title: Radiology CDM ETL Module (one line, title case)
-Version: 1.0
+Version: 1.1
 Authors@R: person("K.I.D", "Neon", email = "contact@neonkid.xyz", role = c("aut", "cre"))
 Description: Dicom Header Extraction Package.
 Depends: 
@@ -20,3 +20,5 @@ License: Apache 2.0
 Encoding: UTF-8
 LazyData: true
 RoxygenNote: 6.1.1
+Suggests: 
+    covr

--- a/R/DICOMFileModule.R
+++ b/R/DICOMFileModule.R
@@ -1,6 +1,3 @@
-require(foreach)
-require(rapportools)
-
 ################################ DcmFileModule Class #############################################
 #' DcmFileModule Class
 #'
@@ -50,6 +47,9 @@ DcmFileModule <- R6::R6Class(classname = "DcmFileModule",
 
   public = list(
     initialize = function(path, savePathRoot, core) {
+      library(foreach)
+      library(rapportools)
+
       private$path <- path
       private$savePathRoot <- savePathRoot
 

--- a/R/DicomRDS.R
+++ b/R/DicomRDS.R
@@ -1,5 +1,3 @@
-library(stringr)
-
 #################################### DicomRDS Class #############################################
 #' DicomRDS Class
 #'
@@ -43,6 +41,7 @@ DicomRDS <- R6::R6Class(classname = "DicomRDS",
   public = list(
     data = NULL,
     initialize = function(data) {
+      library(stringr)
       self$data = data
     },
 

--- a/R/RadiologyDB.R
+++ b/R/RadiologyDB.R
@@ -1,6 +1,3 @@
-require(foreach)
-require(rapportools)
-
 ###################################### RadDB Class #############################################
 #' RadDB Class
 #'
@@ -25,6 +22,9 @@ RadDB <- R6::R6Class(classname = "RadDB",
 
   public = list(
     initialize = function(core) {
+      # library(foreach)
+      # library(rapportools)
+
       # Parallel Processing
       private$cl <- parallel::makePSOCKcluster(core)
       doSNOW::registerDoSNOW(private$cl)
@@ -67,8 +67,8 @@ RadDB <- R6::R6Class(classname = "RadDB",
               dcmRDSk$finalize()
             }
 
-            #pID <- dcmRDS$getPatientID()
-            pID <- dcmRDS$getDirectoryID()
+            pID <- dcmRDS$getPatientID()
+            if(is.na(pID)) pID <- dcmRDS$getDirectoryID()
             coID <- 0
             dcID <- dcmRDS$getDeviceID()
             modality <- dcmRDS$getModality()

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Radiology CDM ETL Module
 
 [![Build Status](https://travis-ci.com/OHDSI/Radiology-CDM.svg?branch=master)](https://travis-ci.com/OHDSI/Radiology-CDM)
+[![codecov.io](https://codecov.io/github/OHDSI/Radiology-CDM/coverage.svg?branch=master)](https://codecov.io/github/OHDSI/Radiology-CDM?branch=master)
 
 
 

--- a/tests/testRadETL.R
+++ b/tests/testRadETL.R
@@ -1,4 +1,3 @@
-.libPaths(c(.libPaths(), Sys.getenv("R_LIB_PATH")))
 library(RadETL)
 
 # Image unpacking -> save RDS file

--- a/tests/testRadETL.R
+++ b/tests/testRadETL.R
@@ -1,0 +1,22 @@
+.libPaths(c(.libPaths(), Sys.getenv("R_LIB_PATH")))
+library(RadETL)
+
+# Image unpacking -> save RDS file
+path <- '~/signedrangeimages/IMAGES'
+savePathRoot <- '~/stored_data/signedrangeimages'
+dfm <- DcmFileModule$new(path = path, savePathRoot = savePathRoot, core = parallel::detectCores() - 1)
+res <- dfm$dcmToRDS(rootPathCount = 4, verbose = FALSE)
+
+# createRadiologyOccurrence
+Rdb <- RadDB$new(core = parallel::detectCores() - 1)
+occur <- Rdb$createRadiologyOccurrence(path = savePathRoot)
+
+# createRadiologyImage
+files <- list.files(path = savePathRoot, pattern = '\\.rds$', full.names = TRUE, recursive = TRUE)
+i <- sample.int(length(files), 1)
+data <- readRDS(file = files[i])
+dRDS <- DicomRDS$new(data = data)
+img <- Rdb$createRadiologyImage(data = data)
+
+print.data.frame(occur, quote = TRUE)
+print.data.frame(img, quote = TRUE)


### PR DESCRIPTION
Fixed #10 
Modified to look at Patient ID built in DICOM before viewing ID in directory.

In addition to the build environment, R 3.4.4 to 3.5.2 version was added. In addition to the package build status, CDM conversion work was added to the test code so that the code can be normally operated (code quality improvement)

Add code coverage to show the extent to which the test code calls the code contained in the package