### PR TITLE
Improved parallel debugging environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,5 +39,5 @@ script:
 
 after_success:
   - Rscript tests/testRadETL.R
-  - cat custom.log
+  - cat /tmp/radiologyDB.log
   - Rscript -e 'library(covr); codecov()'

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,4 +39,5 @@ script:
 
 after_success:
   - Rscript tests/testRadETL.R
+  - cat custom.log
   - Rscript -e 'library(covr); codecov()'

--- a/R/RadiologyDB.R
+++ b/R/RadiologyDB.R
@@ -238,11 +238,14 @@ RadDB <- R6::R6Class(classname = "RadDB",
   ),
 
   public = list(
-    initialize = function(core, log = 'radiologyDB.log') {
+    initialize = function(core, logfile = NA) {
       library(foreach)
 
+      if(is.na(logfile))
+        logfile <- switch(getOS(), cpm = 'C:/TEMP/radiologyDB.log', '/tmp/radiologyDB.log')
+
       # Parallel Processing
-      private$cl <- parallel::makePSOCKcluster(core, outfile = log)
+      private$cl <- parallel::makePSOCKcluster(core, outfile = logfile)
       doSNOW::registerDoSNOW(private$cl)
     },
 

--- a/R/RadiologyDB.R
+++ b/R/RadiologyDB.R
@@ -238,11 +238,11 @@ RadDB <- R6::R6Class(classname = "RadDB",
   ),
 
   public = list(
-    initialize = function(core) {
+    initialize = function(core, log = 'radiologyDB.log') {
       library(foreach)
 
       # Parallel Processing
-      private$cl <- parallel::makePSOCKcluster(core)
+      private$cl <- parallel::makePSOCKcluster(core, outfile = log)
       doSNOW::registerDoSNOW(private$cl)
     },
 

--- a/R/StandardIO.R
+++ b/R/StandardIO.R
@@ -57,11 +57,12 @@ getOS <- function() {
   sysinf <- Sys.info()
   if(!is.null(sysinf)) {
     os <- sysinf['sysname']
-    switch(os, Darwin = 'osx', Linux = 'Linux', 'cpm')
+    os <- switch(os, Darwin = 'osx', Linux = 'Linux', 'cpm')
   } else {
     os <- .Platform$OS.type
     if(grepl("^darwin", R.version$os)) os <- 'osx'
     else if(grepl("^linux-gnu", R.version$os)) os <- 'Linux'
     else os <- 'cpm'
   }
+  return(os)
 }

--- a/R/StandardIO.R
+++ b/R/StandardIO.R
@@ -52,3 +52,16 @@ as.bigint <- function(x, scipen) {
   ret <- as.numeric(x)
   return(ret)
 }
+
+getOS <- function() {
+  sysinf <- Sys.info()
+  if(!is.null(sysinf)) {
+    os <- sysinf['sysname']
+    switch(os, Darwin = 'osx', Linux = 'Linux', 'cpm')
+  } else {
+    os <- .Platform$OS.type
+    if(grepl("^darwin", R.version$os)) os <- 'osx'
+    else if(grepl("^linux-gnu", R.version$os)) os <- 'Linux'
+    else os <- 'cpm'
+  }
+}

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,3 @@
 ignore:
   - "R/DBMSio.R"
+  - "R/StandardIO.R"

--- a/tests/testRadETL.R
+++ b/tests/testRadETL.R
@@ -7,7 +7,7 @@ dfm <- DcmFileModule$new(path = path, savePathRoot = savePathRoot, core = parall
 res <- dfm$dcmToRDS(rootPathCount = 4, verbose = FALSE)
 
 # createRadiologyDB
-Rdb <- RadDB$new(core = parallel::detectCores() - 1, log = 'custom.log')
+Rdb <- RadDB$new(core = parallel::detectCores() - 1)
 rcdm <- Rdb$createRadiologyDB(path = savePathRoot, idp = 2, o_start = 1)
 
 print.data.frame(rcdm[[1]], quote = TRUE) # Occurrence

--- a/tests/testRadETL.R
+++ b/tests/testRadETL.R
@@ -7,7 +7,7 @@ dfm <- DcmFileModule$new(path = path, savePathRoot = savePathRoot, core = parall
 res <- dfm$dcmToRDS(rootPathCount = 4, verbose = FALSE)
 
 # createRadiologyDB
-Rdb <- RadDB$new(core = parallel::detectCores() - 1)
+Rdb <- RadDB$new(core = parallel::detectCores() - 1, log = 'custom.log')
 rcdm <- Rdb$createRadiologyDB(path = savePathRoot, idp = 2, o_start = 1)
 
 print.data.frame(rcdm[[1]], quote = TRUE) # Occurrence


### PR DESCRIPTION
Fixed #25 

Improved to keep track of what happens to them in a parallel processing environment using Socket.

Basically, we tried to use the ```TEMP``` directory provided by OS Platform, and now we have distinguished OS X, Linux, and Windows.

Other users can specify the path of the file directly.